### PR TITLE
Remove [0] for regex return all

### DIFF
--- a/CyvoreOS/checkUtils.py
+++ b/CyvoreOS/checkUtils.py
@@ -19,7 +19,7 @@ def extractUrlAndDomainChecks(data: str) -> List[Check]:
     checks = []
     try:
         logging.debug("extractUrlAndDomainChecks Querying for URLs")
-        urls = re.findall(URLREGEX, data)[0]
+        urls = re.findall(URLREGEX, data)
         if len(urls) > 0:
             urls = set(urls)
             for url in urls:

--- a/CyvoreOS/checkUtils.py
+++ b/CyvoreOS/checkUtils.py
@@ -19,7 +19,7 @@ def extractUrlAndDomainChecks(data: str) -> List[Check]:
     checks = []
     try:
         logging.debug("extractUrlAndDomainChecks Querying for URLs")
-        urls = re.findall(URLREGEX, data)
+        urls = [url[0] for url in re.findall(URLREGEX, data) if url[0]]
         if len(urls) > 0:
             urls = set(urls)
             for url in urls:


### PR DESCRIPTION
Remove [0] for regex return all. 
I don't know why was it there to begin with.